### PR TITLE
Set the default login return URL in the example sp

### DIFF
--- a/examples/sp.py
+++ b/examples/sp.py
@@ -10,6 +10,9 @@ class ServiceProvider(ServiceProvider):
     def get_logout_return_url(self):
         return url_for('index', _external=True)
 
+    def get_default_login_return_url(self):
+        return url_for('index', _external=True)
+
 
 sp = ServiceProvider()
 


### PR DESCRIPTION
Without this I was getting a 405 on `/saml/acs/` rather than seeing the homepage
with the successful login message.