### PR TITLE
Fix a bug with non-signed requests in the IdPHandler class.

### DIFF
--- a/flask_saml2/sp/idphandler.py
+++ b/flask_saml2/sp/idphandler.py
@@ -199,7 +199,7 @@ class IdPHandler:
         if self.sp.should_sign_requests():
             query = sign_query_parameters(self.sp.get_sp_signer(), parameters)
         else:
-            query = urlencode(parameters).encode('utf-8')
+            query = urlencode(parameters)
 
         return f'{url}?{query}'
 


### PR DESCRIPTION
If the service provider isn't signing requests, then the
_make_idp_request_url method turns the query string into a
bytestring before including it in a format string below.

This causes the resulting URL to include the literal characters

b'

preceeding the desired contents of the query string.

This commit removes the call to encode('utf-8') so the url
is generated correctly.