### PR TITLE
Add custom Dropbox Service Provider handler

### DIFF
--- a/docs/source/idp/sphandler.rst
+++ b/docs/source/idp/sphandler.rst
@@ -22,3 +22,6 @@ Some handlers for common Service Providers have been bundled with this project:
 
 .. module:: flask_saml2.idp.sp.google_apps
 .. autoclass:: flask_saml2.idp.sp.google_apps.GoogleAppsSPHandler
+
+.. module:: flask_saml2.idp.sp.dropbox
+.. autoclass:: flask_saml2.idp.sp.dropbox.DropboxSPHandler

--- a/flask_saml2/idp/idp.py
+++ b/flask_saml2/idp/idp.py
@@ -29,6 +29,20 @@ class IdentityProvider(Generic[U]):
 
     blueprint_name = 'flask_saml2_idp'
 
+    #: The specific :class:`digest <~flask_saml2.signing.Digester>` method to
+    #: use in this IdP when creating responses.
+    #:
+    #: See also: :meth:`get_idp_digester`,
+    #: :meth:`~.sp.SPHandler.get_sp_digester`.
+    idp_digester_class: Digester = Sha1Digester
+
+    #: The specific :class:`signing <~flask_saml2.signing.Signer>` method to
+    #: use in this IdP when creating responses.
+    #:
+    #: See also: :meth:`get_idp_signer`,
+    #: :meth:`~.sp.SPHandler.get_sp_signer`.
+    idp_signer_class: Signer = RsaSha1Signer
+
     # Configuration
 
     def get_idp_config(self) -> dict:
@@ -90,11 +104,11 @@ class IdentityProvider(Generic[U]):
         """Get the signing algorithm used by this IdP."""
         private_key = self.get_idp_private_key()
         if private_key is not None:
-            return RsaSha1Signer(private_key)
+            return self.idp_signer_class(private_key)
 
     def get_idp_digester(self) -> Digester:
         """Get the method used to compute digests for the IdP."""
-        return Sha1Digester()
+        return self.idp_digester_class()
 
     def get_service_providers(self) -> Iterable[Tuple[str, dict]]:
         """

--- a/flask_saml2/idp/sp/dropbox.py
+++ b/flask_saml2/idp/sp/dropbox.py
@@ -1,0 +1,22 @@
+import datetime
+
+import pytz
+
+from flask_saml2.idp import SPHandler
+from flask_saml2.signing import Sha256Digester
+
+
+class DropboxSPHandler(SPHandler):
+    """
+    Dropbox :class:`SPHandler` implementation.
+    """
+
+    def get_sp_digester(self):
+        return Sha256Digester()
+
+    def format_datetime(self, value: datetime.datetime) -> str:
+        """
+        Dropbox does not like too much precision in its seconds, and only
+        supports UTC as Z, not an hourly offset.
+        """
+        return value.astimezone(pytz.utc).strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/flask_saml2/idp/sp/dropbox.py
+++ b/flask_saml2/idp/sp/dropbox.py
@@ -3,16 +3,21 @@ import datetime
 import pytz
 
 from flask_saml2.idp import SPHandler
-from flask_saml2.signing import Sha256Digester
+from flask_saml2.signing import RsaSha256Signer, Sha256Digester
 
 
 class DropboxSPHandler(SPHandler):
     """
     Dropbox :class:`SPHandler` implementation.
     """
+    require_destination = False
 
     def get_sp_digester(self):
         return Sha256Digester()
+
+    def get_sp_signer(self):
+        private_key = self.idp.get_idp_private_key()
+        return RsaSha256Signer(private_key)
 
     def format_datetime(self, value: datetime.datetime) -> str:
         """

--- a/flask_saml2/signing.py
+++ b/flask_saml2/signing.py
@@ -102,6 +102,17 @@ class RsaSha1Signer(Signer):
         return base64.b64encode(data).decode('ascii')
 
 
+class RsaSha256Signer(Signer):
+    uri = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+
+    def __init__(self, key: Union[X509, PKey]):
+        self.key = key
+
+    def __call__(self, data: bytes):
+        data = OpenSSL.crypto.sign(self.key, data, "sha256")
+        return base64.b64encode(data).decode('ascii')
+
+
 class SignedInfoTemplate(XmlTemplate):
     """A ``<SignedInfo>`` node, such as:
 

--- a/flask_saml2/signing.py
+++ b/flask_saml2/signing.py
@@ -25,7 +25,7 @@ class Digester:
     Subclasses should set the :attr:`uri` attribute
     and provide a :meth:`make_digest` method.
 
-    Implemented digest methods: :class:`Sha1Digester`.
+    Implemented digest methods: :class:`Sha1Digester`, :class:`Sha256Digester`.
 
     Example:
 
@@ -55,6 +55,13 @@ class Sha1Digester(Digester):
 
     def make_digest(self, data: bytes) -> bytes:
         return hashlib.sha1(data).digest()
+
+
+class Sha256Digester(Digester):
+    uri = 'http://www.w3.org/2001/04/xmlenc#sha256'
+
+    def make_digest(self, data: bytes) -> bytes:
+        return hashlib.sha256(data).digest()
 
 
 class Signer:

--- a/flask_saml2/sp/idphandler.py
+++ b/flask_saml2/sp/idphandler.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Mapping, Optional
 from urllib.parse import urlencode
 
@@ -138,7 +139,7 @@ class IdPHandler:
         """
         return template({
             'REQUEST_ID': get_random_id(),
-            'ISSUE_INSTANT': utcnow().isoformat(),
+            'ISSUE_INSTANT': self.format_datetime(utcnow()),
             'DESTINATION': self.get_idp_sso_url(),
             'ISSUER': self.sp.get_sp_entity_id(),
             'ACS_URL': self.get_sp_acs_url(),
@@ -156,7 +157,7 @@ class IdPHandler:
         """
         return template({
             'REQUEST_ID': get_random_id(),
-            'ISSUE_INSTANT': utcnow().isoformat(),
+            'ISSUE_INSTANT': self.format_datetime(utcnow()),
             'DESTINATION': self.get_idp_slo_url(),
             'ISSUER': self.sp.get_sp_entity_id(),
             'SUBJECT': auth_data.nameid,
@@ -258,6 +259,14 @@ class IdPHandler:
             entity_id = self.sp.get_sp_entity_id()
             if len(audiences) and not any(el.text == entity_id for el in audiences):
                 raise CannotHandleAssertion("No valid AudienceRestriction found")
+
+    def format_datetime(self, value: datetime.datetime) -> str:
+        """
+        Format a datetime for this IdP. Some IdPs are picky about their date
+        formatting, and don't support the format produced by
+        :meth:`datetime.datetime.isoformat`.
+        """
+        return value.isoformat()
 
     def __str__(self):
         if self.display_name:


### PR DESCRIPTION
Based on information in #10 from @fedecastelli. Could you try this fork out, using the DropboxSPHandler instead of your modifications? Without a Dropbox Business account, I have no way of verifying if this works.

Dropbox uses sha256 and does not support sha1. It also requires dates to be formatted a particular way. The DropboxSPHandler handles these quirks. Additional methods were added to the IdentityProvider and SPHandler classes to support these new requirements.

