### PR TITLE
August-W: Made ServiceProvider more configurable without needing to extend it

### DIFF
--- a/examples/sp.py
+++ b/examples/sp.py
@@ -5,16 +5,9 @@ from flask_saml2.sp import ServiceProvider
 from tests.idp.base import CERTIFICATE as IDP_CERTIFICATE
 from tests.sp.base import CERTIFICATE, PRIVATE_KEY
 
-
-class ExampleServiceProvider(ServiceProvider):
-    def get_logout_return_url(self):
-        return url_for('index', _external=True)
-
-    def get_default_login_return_url(self):
-        return url_for('index', _external=True)
-
-
-sp = ExampleServiceProvider()
+sp = ServiceProvider()
+sp.set_default_login_return_endpoint('index')
+sp.set_logout_return_endpoint('index')
 
 app = Flask(__name__)
 app.debug = True

--- a/flask_saml2/sp/views.py
+++ b/flask_saml2/sp/views.py
@@ -28,7 +28,8 @@ class Login(SAML2View):
         handler = self.sp.get_default_idp_handler()
         login_next = self.sp.get_login_return_url()
         if handler:
-            return redirect(url_for('.login_idp', entity_id=handler.entity_id, next=login_next))
+            return redirect(url_for('.login_idp', entity_id=handler.entity_id, next=login_next,
+                            _scheme=self.sp.get_scheme(), _external=True))
         return self.sp.render_template(
             'flask_saml2_sp/choose_idp.html',
             login_next=login_next,
@@ -79,7 +80,10 @@ class SingleLogout(SAML2View):
 class AssertionConsumer(SAML2View):
     def post(self):
         saml_request = request.form['SAMLResponse']
-        relay_state = request.form['RelayState']
+        if self.sp.get_acs_redirect_endpoint() == None:
+            relay_state = request.form['RelayState']
+        else:
+            relay_state = self.sp.make_absolute_url(self.sp.get_acs_redirect_endpoint())
 
         for handler in self.sp.get_idp_handlers():
             try:


### PR DESCRIPTION
Added setters in ServiceProvider for logout_endpoint, login_return_endpoint, and acs_redirect_endpoint, and added parameters in the create_blueprint method. 
With acs_redirect_endpoint, you can explicitly set the relay_state in AssertionConsumer, for cases in which the SAML Request does not contain a relay_state parameter.

Fixed an issue with the Login class in views.py. It now supports setting the scheme to "https" (this happens in ServiceProvider's create_blueprint method).

Updated the example sp.py accordingly.