### PR TITLE
Multiple Values for a SAML Attribute

### DIFF
--- a/flask_saml2/sp/parser.py
+++ b/flask_saml2/sp/parser.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, List, Union
+from typing import List, Mapping, Optional, Union
 
 from flask_saml2.types import XmlNode
 from flask_saml2.utils import cached_property

--- a/flask_saml2/sp/parser.py
+++ b/flask_saml2/sp/parser.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional
+from typing import Mapping, Optional, List, Union
 
 from flask_saml2.types import XmlNode
 from flask_saml2.utils import cached_property
@@ -51,10 +51,20 @@ class ResponseParser(XmlParser):
         return self._xpath(self.subject, 'saml:NameID/@Format')[0]
 
     @cached_property
-    def attributes(self) -> Mapping[str, str]:
+    def attributes(self) -> Mapping[str, Union[str, List[str]]]:
         attributes = self._xpath(self.assertion, 'saml:AttributeStatement/saml:Attribute')
-        return {el.get('Name'): self._xpath(el, 'saml:AttributeValue')[0].text
-                for el in attributes}
+        ret = {}
+        for el in attributes:
+            name = el.get('Name')
+            attrs = self._xpath(el, 'saml:AttributeValue')
+            if len(attrs) == 1:
+                ret[name] = attrs[0].text
+            else:
+                vals = []
+                for a in attrs:
+                    vals.append(a.text)
+                ret[name] = vals
+        return ret
 
     @cached_property
     def conditions(self) -> Optional[XmlNode]:


### PR DESCRIPTION
Allows for a SAML attribute to have multiple values.

Partially solves #24 