### PR TITLE
Change defaults to sha256 from deprecated sha1

### DIFF
--- a/flask_saml2/idp/idp.py
+++ b/flask_saml2/idp/idp.py
@@ -3,7 +3,8 @@ from typing import Generic, Iterable, Optional, Tuple, TypeVar
 from flask import Blueprint, current_app, render_template, url_for
 
 from flask_saml2.exceptions import CannotHandleAssertion, UserNotAuthorized
-from flask_saml2.signing import Digester, RsaSha1Signer, Sha1Digester, Signer
+from flask_saml2.signing import (
+    Digester, RsaSha256Signer, Sha256Digester, Signer)
 from flask_saml2.types import X509, PKey
 from flask_saml2.utils import certificate_to_string, import_string
 
@@ -34,14 +35,14 @@ class IdentityProvider(Generic[U]):
     #:
     #: See also: :meth:`get_idp_digester`,
     #: :meth:`~.sp.SPHandler.get_sp_digester`.
-    idp_digester_class: Digester = Sha1Digester
+    idp_digester_class: Digester = Sha256Digester
 
     #: The specific :class:`signing <~flask_saml2.signing.Signer>` method to
     #: use in this IdP when creating responses.
     #:
     #: See also: :meth:`get_idp_signer`,
     #: :meth:`~.sp.SPHandler.get_sp_signer`.
-    idp_signer_class: Signer = RsaSha1Signer
+    idp_signer_class: Signer = RsaSha256Signer
 
     # Configuration
 

--- a/flask_saml2/sp/sp.py
+++ b/flask_saml2/sp/sp.py
@@ -7,7 +7,8 @@ from flask import (
     session, url_for)
 
 from flask_saml2.exceptions import CannotHandleAssertion
-from flask_saml2.signing import Digester, RsaSha1Signer, Sha1Digester, Signer
+from flask_saml2.signing import (
+    Digester, RsaSha256Signer, Sha256Digester, Signer)
 from flask_saml2.types import X509, PKey
 from flask_saml2.utils import certificate_to_string, import_string
 
@@ -97,11 +98,11 @@ class ServiceProvider:
         """Get the signing algorithm used by this SP."""
         private_key = self.get_sp_private_key()
         if private_key is not None:
-            return RsaSha1Signer(private_key)
+            return RsaSha256Signer(private_key)
 
     def get_sp_digester(self) -> Digester:
         """Get the digest algorithm used by this SP."""
-        return Sha1Digester()
+        return Sha256Digester()
 
     def should_sign_requests(self) -> bool:
         """

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup_kwargs = dict(
         'Flask>=1.0.0',
         'signxml>=2.4.0',
         'lxml>=3.8.0',
-        'pyopenssl<18',
+        'pyopenssl==23.1.1',
         'defusedxml>=0.5.0',
         'pytz>=0',
         'iso8601~=0.1.12',


### PR DESCRIPTION
SHA1 is deprecated. Change signer and digester to use sha256 by default in IdP and SP. Addresses #38 #40